### PR TITLE
fixed slice bounds out of range panic in syslog handler

### DIFF
--- a/handlers/syslog/syslog.go
+++ b/handlers/syslog/syslog.go
@@ -6,6 +6,7 @@ import (
 	stdlog "log"
 	"os"
 	"strconv"
+	"strings"
 
 	syslog "github.com/RackSec/srslog"
 
@@ -349,7 +350,9 @@ func defaultFormatFunc(s *Syslog) Formatter {
 					}
 				}
 			} else {
-				file = file[len(gopath):]
+				if strings.HasPrefix(file, gopath) {
+					file = file[len(gopath):]
+				}
 			}
 
 			b = append(b, e.Timestamp.Format(tsFormat)...)


### PR DESCRIPTION
The syslog handler panics when fnameDisplay is set to Llongfile and a log is triggered by code from a source file which is not located somewhere beneath 'gopath':

  panic: runtime error: slice bounds out of range

I know, I know, it's not how you're supposed to organise your Go code - nevertheless I managed to trip the panic while just playing around with the log library (which I like very much BTW!)

In any case, this small patch guards against the condition and just leaves the original path alone if the source file path is not within 'gopath'.