### PR TITLE
New SetExitFunc() so wrappers can test Fatal().

### DIFF
--- a/log.go
+++ b/log.go
@@ -355,10 +355,17 @@ func (l *logger) SetCallerInfoLevels(levels ...Level) {
 }
 
 // SetCallerSkipDiff adds the provided diff to the caller SkipLevel values.
-// This is used when wrapping this library, you can set ths to increase the
+// This is used when wrapping this library, you can set this to increase the
 // skip values passed to Caller that retrieves the file + line number info.
 func (l *logger) SetCallerSkipDiff(diff uint8) {
 	skipLevel += int(diff)
+}
+
+// SetExitFunc sets the provided function as the exit function used in Fatal()
+// and FatalF(). This is used when wrapping this library, you can set this to
+// to enable testing (with coverage) of your Fatal() and FatalF() methods.
+func (l *logger) SetExitFunc(ef func(code int)) {
+	exitFunc = ef
 }
 
 // HasHandlers returns if any handlers have been registered.

--- a/log_test.go
+++ b/log_test.go
@@ -369,9 +369,9 @@ func TestEntry(t *testing.T) {
 func TestFatal(t *testing.T) {
 	var i int
 
-	exitFunc = func(code int) {
+	Logger.SetExitFunc(func(code int) {
 		i = code
-	}
+	})
 
 	Logger.Fatal("fatal")
 	if i != 1 {

--- a/pkg.go
+++ b/pkg.go
@@ -223,6 +223,13 @@ func SetCallerSkipDiff(diff uint8) {
 	Logger.SetCallerSkipDiff(diff)
 }
 
+// SetExitFunc sets the provided function as the exit function used in Fatal()
+// and FatalF(). This is used when wrapping this library, you can set this to
+// to enable testing (with coverage) of your Fatal() and FatalF() methods.
+func SetExitFunc(ef func(code int)) {
+	exitFunc = ef
+}
+
 // HasHandlers returns if any handlers have been registered.
 func HasHandlers() bool {
 	return Logger.HasHandlers()


### PR DESCRIPTION
Hi,

I'm wrapping your log package and would like to get test coverage on my own Fatal() method that calls yours. I hope you will agree that the changes I propose here that allow this are harmless to any existing users of your code and possibly beneficial to others.

Thanks!