### PR TITLE
Configurable WithError function

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ## log
-<img align="right" src="https://raw.githubusercontent.com/go-playground/log/master/logo.png">![Project status](https://img.shields.io/badge/version-5.0.2-green.svg)
+<img align="right" src="https://raw.githubusercontent.com/go-playground/log/master/logo.png">![Project status](https://img.shields.io/badge/version-6.0.0-green.svg)
 [![Build Status](https://semaphoreci.com/api/v1/joeybloggs/log/branches/master/badge.svg)](https://semaphoreci.com/joeybloggs/log)
 [![Coverage Status](https://coveralls.io/repos/github/go-playground/log/badge.svg?branch=master)](https://coveralls.io/github/go-playground/log?branch=master)
 [![Go Report Card](https://goreportcard.com/badge/github.com/go-playground/log)](https://goreportcard.com/report/github.com/go-playground/log)
@@ -21,6 +21,9 @@ Features
 - [x] Handlers are simple to write + easy to register
 - [x] Logger is a singleton ( one of the few instances a singleton is desired ) so the root package registers which handlers are used and any libraries just follow suit.
 - [x] Convenient context helpers `GetContext` & `SetContext`
+- [x] Works with go-playground/errors extracting types and tags when used with `WithError`, is the default
+- [x] Works with pkg/errors when used with `WithError`, must set using `SetWithErrFn`
+- [x] Works with segmentio/errors-go extracting types and tags when used with `WithError`, must set using `SetWithErrFn`
 
 Installation
 -----------

--- a/entry.go
+++ b/entry.go
@@ -2,10 +2,7 @@ package log
 
 import (
 	"fmt"
-	"strings"
 	"time"
-
-	"github.com/pkg/errors"
 )
 
 // Fields is the type to send to WithFields
@@ -48,8 +45,8 @@ func (e Entry) WithFields(fields ...Field) Entry {
 	return ne
 }
 
-// WithTrace withh add duration of how long the between this function call and
-// the susequent log
+// WithTrace with add duration of how long the between this function call and
+// the subsequent log
 func (e Entry) WithTrace() Entry {
 	e.start = time.Now()
 	return e
@@ -57,31 +54,7 @@ func (e Entry) WithTrace() Entry {
 
 // WithError add a minimal stack trace to the log Entry
 func (e Entry) WithError(err error) Entry {
-	return e.withError(err)
-}
-
-// WithError add a minimal stack trace to the log Entry
-func (e Entry) withError(err error) Entry {
-	ne := newEntry(e)
-	ne.Fields = append(ne.Fields, Field{Key: "error", Value: err.Error()})
-
-	var frame errors.Frame
-
-	if s, ok := err.(stackTracer); ok {
-		frame = s.StackTrace()[0]
-	} else {
-		frame = errors.WithStack(err).(stackTracer).StackTrace()[2:][0]
-	}
-
-	name := fmt.Sprintf("%n", frame)
-	file := fmt.Sprintf("%+s", frame)
-	line := fmt.Sprintf("%d", frame)
-	parts := strings.Split(file, "\n\t")
-	if len(parts) > 1 {
-		file = parts[1]
-	}
-	ne.Fields = append(ne.Fields, Field{Key: "source", Value: fmt.Sprintf("%s: %s:%s", name, file, line)})
-	return ne
+	return withErrFn(e, err)
 }
 
 // Debug logs a debug entry

--- a/entry.go
+++ b/entry.go
@@ -61,63 +61,63 @@ func (e Entry) WithError(err error) Entry {
 func (e Entry) Debug(v ...interface{}) {
 	e.Message = fmt.Sprint(v...)
 	e.Level = DebugLevel
-	handleEntry(e)
+	HandleEntry(e)
 }
 
 // Debugf logs a debug entry with formatting
 func (e Entry) Debugf(s string, v ...interface{}) {
 	e.Message = fmt.Sprintf(s, v...)
 	e.Level = DebugLevel
-	handleEntry(e)
+	HandleEntry(e)
 }
 
 // Info logs a normal. information, entry
 func (e Entry) Info(v ...interface{}) {
 	e.Message = fmt.Sprint(v...)
 	e.Level = InfoLevel
-	handleEntry(e)
+	HandleEntry(e)
 }
 
 // Infof logs a normal. information, entry with formatting
 func (e Entry) Infof(s string, v ...interface{}) {
 	e.Message = fmt.Sprintf(s, v...)
 	e.Level = InfoLevel
-	handleEntry(e)
+	HandleEntry(e)
 }
 
 // Notice logs a notice log entry
 func (e Entry) Notice(v ...interface{}) {
 	e.Message = fmt.Sprint(v...)
 	e.Level = NoticeLevel
-	handleEntry(e)
+	HandleEntry(e)
 }
 
 // Noticef logs a notice log entry with formatting
 func (e Entry) Noticef(s string, v ...interface{}) {
 	e.Message = fmt.Sprintf(s, v...)
 	e.Level = NoticeLevel
-	handleEntry(e)
+	HandleEntry(e)
 }
 
 // Warn logs a warn log entry
 func (e Entry) Warn(v ...interface{}) {
 	e.Message = fmt.Sprint(v...)
 	e.Level = WarnLevel
-	handleEntry(e)
+	HandleEntry(e)
 }
 
 // Warnf logs a warn log entry with formatting
 func (e Entry) Warnf(s string, v ...interface{}) {
 	e.Message = fmt.Sprintf(s, v...)
 	e.Level = WarnLevel
-	handleEntry(e)
+	HandleEntry(e)
 }
 
 // Panic logs a panic log entry
 func (e Entry) Panic(v ...interface{}) {
 	e.Message = fmt.Sprint(v...)
 	e.Level = PanicLevel
-	handleEntry(e)
+	HandleEntry(e)
 	exitFunc(1)
 }
 
@@ -125,7 +125,7 @@ func (e Entry) Panic(v ...interface{}) {
 func (e Entry) Panicf(s string, v ...interface{}) {
 	e.Message = fmt.Sprintf(s, v...)
 	e.Level = PanicLevel
-	handleEntry(e)
+	HandleEntry(e)
 	exitFunc(1)
 }
 
@@ -133,21 +133,21 @@ func (e Entry) Panicf(s string, v ...interface{}) {
 func (e Entry) Alert(v ...interface{}) {
 	e.Message = fmt.Sprint(v...)
 	e.Level = AlertLevel
-	handleEntry(e)
+	HandleEntry(e)
 }
 
 // Alertf logs an alert log entry with formatting
 func (e Entry) Alertf(s string, v ...interface{}) {
 	e.Message = fmt.Sprintf(s, v...)
 	e.Level = AlertLevel
-	handleEntry(e)
+	HandleEntry(e)
 }
 
 // Fatal logs a fatal log entry
 func (e Entry) Fatal(v ...interface{}) {
 	e.Message = fmt.Sprint(v...)
 	e.Level = FatalLevel
-	handleEntry(e)
+	HandleEntry(e)
 	exitFunc(1)
 }
 
@@ -155,7 +155,7 @@ func (e Entry) Fatal(v ...interface{}) {
 func (e Entry) Fatalf(s string, v ...interface{}) {
 	e.Message = fmt.Sprintf(s, v...)
 	e.Level = FatalLevel
-	handleEntry(e)
+	HandleEntry(e)
 	exitFunc(1)
 }
 
@@ -163,12 +163,12 @@ func (e Entry) Fatalf(s string, v ...interface{}) {
 func (e Entry) Error(v ...interface{}) {
 	e.Message = fmt.Sprint(v...)
 	e.Level = ErrorLevel
-	handleEntry(e)
+	HandleEntry(e)
 }
 
 // Errorf logs an error log entry with formatting
 func (e Entry) Errorf(s string, v ...interface{}) {
 	e.Message = fmt.Sprintf(s, v...)
 	e.Level = ErrorLevel
-	handleEntry(e)
+	HandleEntry(e)
 }

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,31 @@
+package log
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+func pkgErrorsWithError(e Entry, err error) Entry {
+	ne := newEntry(e)
+	ne.Fields = append(ne.Fields, Field{Key: "error", Value: err.Error()})
+
+	var frame errors.Frame
+
+	if s, ok := err.(stackTracer); ok {
+		frame = s.StackTrace()[0]
+	} else {
+		frame = errors.WithStack(err).(stackTracer).StackTrace()[2:][0]
+	}
+
+	name := fmt.Sprintf("%n", frame)
+	file := fmt.Sprintf("%+s", frame)
+	line := fmt.Sprintf("%d", frame)
+	parts := strings.Split(file, "\n\t")
+	if len(parts) > 1 {
+		file = parts[1]
+	}
+	ne.Fields = append(ne.Fields, Field{Key: "source", Value: fmt.Sprintf("%s: %s:%s", name, file, line)})
+	return ne
+}

--- a/errors.go
+++ b/errors.go
@@ -4,28 +4,49 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/pkg/errors"
+	"github.com/go-playground/errors"
 )
 
-func pkgErrorsWithError(e Entry, err error) Entry {
+func errorsWithError(e Entry, err error) Entry {
 	ne := newEntry(e)
-	ne.Fields = append(ne.Fields, Field{Key: "error", Value: err.Error()})
 
-	var frame errors.Frame
+	if w, ok := err.(*errors.Wrapped); ok {
+		cause := errors.Cause(w).(*errors.Wrapped)
+		ne.Fields = append(ne.Fields, Field{Key: "error", Value: fmt.Sprintf("%s: %s", cause.Prefix, cause.Err)})
+		ne.Fields = append(ne.Fields, Field{Key: "source", Value: cause.Source})
+		if len(w.Errors) > 0 {
+			// top level error
+			types := make([]string, 0, len(w.Errors))
+			for _, e := range w.Errors {
+				for _, tag := range e.Tags {
+					ne.Fields = append(ne.Fields, Field{Key: tag.Key, Value: tag.Value})
+				}
+				types = append(types, e.Types...)
+			}
+			if len(types) > 0 {
+				ne.Fields = append(ne.Fields, Field{Key: "types", Value: strings.Join(types, ",")})
+			}
+		} else {
+			// not top level, probably cause
+			for _, tag := range w.Tags {
+				ne.Fields = append(ne.Fields, Field{Key: tag.Key, Value: tag.Value})
+			}
+			if len(w.Types) > 0 {
+				ne.Fields = append(ne.Fields, Field{Key: "types", Value: strings.Join(w.Types, ",")})
+			}
+		}
 
-	if s, ok := err.(stackTracer); ok {
-		frame = s.StackTrace()[0]
 	} else {
-		frame = errors.WithStack(err).(stackTracer).StackTrace()[2:][0]
+		ne.Fields = append(ne.Fields, Field{Key: "error", Value: err.Error()})
+		frame := errors.StackLevel(2)
+		name := fmt.Sprintf("%n", frame)
+		file := fmt.Sprintf("%+s", frame)
+		line := fmt.Sprintf("%d", frame)
+		parts := strings.Split(file, "\n\t")
+		if len(parts) > 1 {
+			file = parts[1]
+		}
+		ne.Fields = append(ne.Fields, Field{Key: "source", Value: fmt.Sprintf("%s: %s:%s", name, file, line)})
 	}
-
-	name := fmt.Sprintf("%n", frame)
-	file := fmt.Sprintf("%+s", frame)
-	line := fmt.Sprintf("%d", frame)
-	parts := strings.Split(file, "\n\t")
-	if len(parts) > 1 {
-		file = parts[1]
-	}
-	ne.Fields = append(ne.Fields, Field{Key: "source", Value: fmt.Sprintf("%s: %s:%s", name, file, line)})
 	return ne
 }

--- a/errors/pkg/pkg_test.go
+++ b/errors/pkg/pkg_test.go
@@ -1,0 +1,54 @@
+package pkg
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/go-playground/log"
+	"github.com/pkg/errors"
+)
+
+type testHandler struct {
+	writer io.Writer
+}
+
+func (th *testHandler) Log(e log.Entry) {
+	s := e.Level.String() + " "
+	s += e.Message
+
+	for _, f := range e.Fields {
+		s += fmt.Sprintf(" %s=%v", f.Key, f.Value)
+	}
+	s += "\n"
+	if _, err := th.writer.Write([]byte(s)); err != nil {
+		panic(err)
+	}
+}
+
+func TestWrappedError(t *testing.T) {
+	log.SetExitFunc(func(int) {})
+	log.SetWithErrorFn(ErrorsWithError)
+	buff := new(bytes.Buffer)
+	th := &testHandler{
+		writer: buff,
+	}
+	log.AddHandler(th, log.AllLevels...)
+
+	err := fmt.Errorf("this is an %s", "error")
+	err = errors.Wrap(err, "prefix")
+	log.WithError(err).Error("test")
+	expected := "pkg_test.go:41\n"
+	if !strings.HasSuffix(buff.String(), expected) {
+		t.Errorf("got %s Expected %s", buff.String(), expected)
+	}
+	buff.Reset()
+	expected = "pkg_test.go:50\n"
+	err = fmt.Errorf("this is an %s", "error")
+	log.WithError(err).Error("test")
+	if !strings.HasSuffix(buff.String(), expected) {
+		t.Errorf("got %s Expected %s", buff.String(), expected)
+	}
+}

--- a/errors/segmentio/segmentio.go
+++ b/errors/segmentio/segmentio.go
@@ -1,0 +1,52 @@
+package segmentio
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/go-playground/log"
+
+	"github.com/segmentio/errors-go"
+)
+
+type stackTracer interface {
+	StackTrace() errors.StackTrace
+}
+
+// ErrorsGoWithError is a custom WithError function that can be used by using log's
+// SetWithErrorFn function.
+func ErrorsGoWithError(e log.Entry, err error) log.Entry {
+	// normally would call newEntry, but instead will shallow copy
+	// because it's not exposed.
+	ne := new(log.Entry)
+	*ne = *(&e)
+
+	flds := make([]log.Field, 0, len(e.Fields))
+	flds = append(flds, e.Fields...)
+	flds = append(flds, log.Field{Key: "error", Value: err.Error()})
+	ne.Fields = flds
+
+	var frame errors.Frame
+
+	_, _, tags, stacks, _ := errors.Inspect(err)
+
+	if len(stacks) > 0 {
+		frame = stacks[len(stacks)-1][0]
+	} else {
+		frame = errors.WithStack(err).(stackTracer).StackTrace()[2:][0]
+	}
+
+	name := fmt.Sprintf("%n", frame)
+	file := fmt.Sprintf("%+s", frame)
+	line := fmt.Sprintf("%d", frame)
+	parts := strings.Split(file, "\n\t")
+	if len(parts) > 1 {
+		file = parts[1]
+	}
+	ne.Fields = append(ne.Fields, log.Field{Key: "source", Value: fmt.Sprintf("%s: %s:%s", name, file, line)})
+
+	for _, tag := range tags {
+		ne.Fields = append(ne.Fields, log.Field{Key: tag.Name, Value: tag.Value})
+	}
+	return *ne
+}

--- a/errors/segmentio/segmentio_test.go
+++ b/errors/segmentio/segmentio_test.go
@@ -1,0 +1,56 @@
+package segmentio
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/go-playground/log"
+	"github.com/segmentio/errors-go"
+)
+
+type testHandler struct {
+	writer io.Writer
+}
+
+func (th *testHandler) Log(e log.Entry) {
+	s := e.Level.String() + " "
+	s += e.Message
+
+	for _, f := range e.Fields {
+		s += fmt.Sprintf(" %s=%v", f.Key, f.Value)
+	}
+	s += "\n"
+	if _, err := th.writer.Write([]byte(s)); err != nil {
+		panic(err)
+	}
+}
+
+func TestWrappedError(t *testing.T) {
+	log.SetExitFunc(func(int) {})
+	log.SetWithErrorFn(ErrorsGoWithError)
+	buff := new(bytes.Buffer)
+	th := &testHandler{
+		writer: buff,
+	}
+	log.AddHandler(th, log.AllLevels...)
+
+	err := fmt.Errorf("this is an %s", "error")
+	err = errors.WithTypes(errors.WithTags(errors.Wrap(err, "prefix"),
+		errors.T("key", "value"),
+	), "Permanent", "Internal")
+	log.WithError(err).Error("test")
+	expected := "segmentio_test.go:41 key=value types=Internal,Permanent\n"
+	if !strings.HasSuffix(buff.String(), expected) {
+		t.Errorf("got %s Expected %s", buff.String(), expected)
+	}
+	buff.Reset()
+	expected = "segmentio_test.go:52\n"
+	err = fmt.Errorf("this is an %s", "error")
+	log.WithError(err).Error("test")
+	if !strings.HasSuffix(buff.String(), expected) {
+		t.Errorf("got %s Expected %s", buff.String(), expected)
+	}
+}

--- a/log.go
+++ b/log.go
@@ -16,7 +16,7 @@ var (
 	logFields   []Field
 	logHandlers = map[Level][]Handler{}
 	exitFunc    = os.Exit
-	withErrFn   = pkgErrorsWithError
+	withErrFn   = errorsWithError
 	ctxIdent    = &struct {
 		name string
 	}{
@@ -58,7 +58,10 @@ func GetContext(ctx context.Context) Entry {
 	return v.(Entry)
 }
 
-func handleEntry(e Entry) {
+// HandleEntry handles the log entry and fans out to all handlers with the proper log level
+// This is exposed to allow for centralized logging whereby the log entry is marshalled, passed
+// to a central logging server, unmarshalled and finally fanned out from there.
+func HandleEntry(e Entry) {
 	if !e.start.IsZero() {
 		e = e.WithField("duration", time.Since(e.start))
 	}

--- a/log.go
+++ b/log.go
@@ -16,6 +16,7 @@ var (
 	logFields   []Field
 	logHandlers = map[Level][]Handler{}
 	exitFunc    = os.Exit
+	withErrFn   = pkgErrorsWithError
 	ctxIdent    = &struct {
 		name string
 	}{
@@ -35,6 +36,11 @@ type Field struct {
 // methods.
 func SetExitFunc(fn func(code int)) {
 	exitFunc = fn
+}
+
+// SetWithErrorFn sets a custom WithError function handlers
+func SetWithErrorFn(fn func(Entry, error) Entry) {
+	withErrFn = fn
 }
 
 // SetContext sets a log entry into the provided context
@@ -108,7 +114,7 @@ func WithTrace() Entry {
 // WithError add a minimal stack trace to the log Entry
 func WithError(err error) Entry {
 	ne := newEntryWithFields(logFields)
-	return ne.withError(err)
+	return withErrFn(ne, err)
 }
 
 // Debug logs a debug entry

--- a/log_test.go
+++ b/log_test.go
@@ -51,6 +51,7 @@ type test struct {
 
 func TestConsoleLogger1(t *testing.T) {
 	SetExitFunc(func(int) {})
+	SetWithErrorFn(pkgErrorsWithError)
 	tests := getLogTests1()
 	buff := new(bytes.Buffer)
 	th := &testHandler{
@@ -58,7 +59,6 @@ func TestConsoleLogger1(t *testing.T) {
 	}
 	logHandlers = map[Level][]Handler{}
 	AddHandler(th, AllLevels...)
-
 	for i, tt := range tests {
 		buff.Reset()
 		var l Entry

--- a/stack.go
+++ b/stack.go
@@ -1,7 +1,0 @@
-package log
-
-import "github.com/pkg/errors"
-
-type stackTracer interface {
-	StackTrace() errors.StackTrace
-}


### PR DESCRIPTION
This is a major version bump to v6.0.0, for most there will be no changes at all, but was a possibility for those using pkg/errors so just being cautious.

- Exposed `HandleEntry` to allow for centralized logging.
- Add ability to customize `WithError` functionality
  - uses go-playground/errors by default as the default `WithError` function
  - custom pkg/errors `WithError` function exists under `errors/pkg`
  - custom segmentio/errors-go `WithError` function exists under `errors/segmentio`