### PR TITLE
Fix go modules implementation to work with versions > v6

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ package main
 import (
 	"errors"
 
-	"github.com/go-playground/log"
-	"github.com/go-playground/log/handlers/console"
+	"github.com/go-playground/log/v7"
+	"github.com/go-playground/log/v7/handlers/console"
 )
 
 func main() {
@@ -96,7 +96,7 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/go-playground/log"
+	"github.com/go-playground/log/v7"
 )
 
 // CustomHandler is your custom handler

--- a/_examples/basic/main.go
+++ b/_examples/basic/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/go-playground/errors"
-	"github.com/go-playground/log"
+	"github.com/go-playground/log/v7"
 )
 
 func main() {

--- a/_examples/basic/main.go
+++ b/_examples/basic/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/go-playground/errors"
+	"github.com/go-playground/errors/v5"
 	"github.com/go-playground/log/v7"
 )
 

--- a/_examples/custom-handler/main.go
+++ b/_examples/custom-handler/main.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/go-playground/log"
+	"github.com/go-playground/log/v7"
 )
 
 // CustomHandler is your custom handler

--- a/_examples/handler/main.go
+++ b/_examples/handler/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/go-playground/errors"
+	"github.com/go-playground/errors/v5"
 
 	"github.com/go-playground/log/v7"
 	"github.com/go-playground/log/v7/handlers/console"

--- a/_examples/handler/main.go
+++ b/_examples/handler/main.go
@@ -3,8 +3,8 @@ package main
 import (
 	"github.com/go-playground/errors"
 
-	"github.com/go-playground/log"
-	"github.com/go-playground/log/handlers/console"
+	"github.com/go-playground/log/v7"
+	"github.com/go-playground/log/v7/handlers/console"
 )
 
 func main() {

--- a/benchmarks/benchmark_test.go
+++ b/benchmarks/benchmark_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-playground/log"
-	"github.com/go-playground/log/handlers/console"
+	"github.com/go-playground/log/v7"
+	"github.com/go-playground/log/v7/handlers/console"
 )
 
 var errExample = errors.New("fail")

--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -5,7 +5,7 @@ import (
 	stderr "errors"
 	"testing"
 
-	"github.com/go-playground/errors"
+	"github.com/go-playground/errors/v5"
 )
 
 func BenchmarkWithError(b *testing.B) {

--- a/errors.go
+++ b/errors.go
@@ -3,8 +3,8 @@ package log
 import (
 	"fmt"
 
-	"github.com/go-playground/errors"
-	runtimeext "github.com/go-playground/pkg/runtime"
+	"github.com/go-playground/errors/v5"
+	runtimeext "github.com/go-playground/pkg/v3/runtime"
 )
 
 func errorsWithError(e Entry, err error) Entry {

--- a/errors/pkg/pkg.go
+++ b/errors/pkg/pkg.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/go-playground/log"
+	"github.com/go-playground/log/v7"
 	"github.com/pkg/errors"
 )
 

--- a/errors/pkg/pkg_test.go
+++ b/errors/pkg/pkg_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/go-playground/log"
+	"github.com/go-playground/log/v7"
 	"github.com/pkg/errors"
 )
 

--- a/errors/segmentio/segmentio.go
+++ b/errors/segmentio/segmentio.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/go-playground/log"
+	"github.com/go-playground/log/v7"
 
 	"github.com/segmentio/errors-go"
 )

--- a/errors/segmentio/segmentio_test.go
+++ b/errors/segmentio/segmentio_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/go-playground/log"
+	"github.com/go-playground/log/v7"
 	"github.com/segmentio/errors-go"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/RackSec/srslog v0.0.0-20180709174129-a4725f04ec91
 	github.com/go-playground/ansi v2.1.0+incompatible
 	github.com/go-playground/errors v0.0.0-20190511183022-b661b75d4162
+	github.com/go-playground/log v6.3.0+incompatible
 	github.com/go-playground/pkg v0.0.0-20190511145249-fa4bcb050f1d
 	github.com/pkg/errors v0.8.1
 	github.com/segmentio/errors-go v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/go-playground/log
+module github.com/go-playground/log/v7
 
 go 1.11
 

--- a/go.mod
+++ b/go.mod
@@ -5,9 +5,8 @@ go 1.11
 require (
 	github.com/RackSec/srslog v0.0.0-20180709174129-a4725f04ec91
 	github.com/go-playground/ansi v2.1.0+incompatible
-	github.com/go-playground/errors v0.0.0-20190511183022-b661b75d4162
-	github.com/go-playground/log v6.3.0+incompatible
-	github.com/go-playground/pkg v0.0.0-20190511145249-fa4bcb050f1d
+	github.com/go-playground/errors/v5 v5.0.0
+	github.com/go-playground/pkg/v3 v3.1.5
 	github.com/pkg/errors v0.8.1
 	github.com/segmentio/errors-go v1.0.0
 	golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/go-playground/ansi v2.1.0+incompatible/go.mod h1:OCdnfTFO/GfFtp+ktUt+
 github.com/go-playground/errors v0.0.0-20190511183022-b661b75d4162 h1:E0/Tcjy4E1wyBgwyb+ufYEzQaxnPXkBbs0nbfy9HNVw=
 github.com/go-playground/errors v0.0.0-20190511183022-b661b75d4162/go.mod h1:V/gdJTQRLs5Bsu3bIcSmQbIRdQwXq+OajaRrGpCNEqY=
 github.com/go-playground/form v3.1.4+incompatible/go.mod h1:lhcKXfTuhRtIZCIKUeJ0b5F207aeQCPbZU09ScKjwWg=
+github.com/go-playground/log v6.3.0+incompatible h1:CVT3y82/iLS65WJ4xfF8+SI6dxRdMiXpX+9surI/R2U=
+github.com/go-playground/log v6.3.0+incompatible/go.mod h1:3M1OvdKL8KYwOjJa3XM42iqzpvde2LHla8Ys0oz7Ma0=
 github.com/go-playground/pkg v0.0.0-20190511145249-fa4bcb050f1d h1:dLyXECWWFoQAp49e+ayPJyTcVAVOSAEmZ/QALeOuIfg=
 github.com/go-playground/pkg v0.0.0-20190511145249-fa4bcb050f1d/go.mod h1:Wg1j+HqWLhhVIfYdaoOuBzdutBEVcqwvBxgFZRWbybk=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/go.sum
+++ b/go.sum
@@ -5,9 +5,9 @@ github.com/go-playground/ansi v2.1.0+incompatible h1:f9ldskdk1seTFmYjbmPaYB+WYsD
 github.com/go-playground/ansi v2.1.0+incompatible/go.mod h1:OCdnfTFO/GfFtp+ktUt+PhElbGOwyTRUuRUsA+Y5pSU=
 github.com/go-playground/errors v0.0.0-20190511183022-b661b75d4162 h1:E0/Tcjy4E1wyBgwyb+ufYEzQaxnPXkBbs0nbfy9HNVw=
 github.com/go-playground/errors v0.0.0-20190511183022-b661b75d4162/go.mod h1:V/gdJTQRLs5Bsu3bIcSmQbIRdQwXq+OajaRrGpCNEqY=
+github.com/go-playground/errors v3.3.0+incompatible h1:w7qP6bdFXNmI86aV8VEfhXrGxoQWYHc/OX4Muw4FgW0=
+github.com/go-playground/errors v3.3.0+incompatible/go.mod h1:n+RcthKmtLxDczVHKkhqiUSOGtTjvRl+HB4Gga0vWSI=
 github.com/go-playground/form v3.1.4+incompatible/go.mod h1:lhcKXfTuhRtIZCIKUeJ0b5F207aeQCPbZU09ScKjwWg=
-github.com/go-playground/log v6.3.0+incompatible h1:CVT3y82/iLS65WJ4xfF8+SI6dxRdMiXpX+9surI/R2U=
-github.com/go-playground/log v6.3.0+incompatible/go.mod h1:3M1OvdKL8KYwOjJa3XM42iqzpvde2LHla8Ys0oz7Ma0=
 github.com/go-playground/pkg v0.0.0-20190511145249-fa4bcb050f1d h1:dLyXECWWFoQAp49e+ayPJyTcVAVOSAEmZ/QALeOuIfg=
 github.com/go-playground/pkg v0.0.0-20190511145249-fa4bcb050f1d/go.mod h1:Wg1j+HqWLhhVIfYdaoOuBzdutBEVcqwvBxgFZRWbybk=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/handlers/console/console.go
+++ b/handlers/console/console.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 
 	"github.com/go-playground/ansi"
-	"github.com/go-playground/log"
+	"github.com/go-playground/log/v7"
 )
 
 const (

--- a/handlers/console/console_test.go
+++ b/handlers/console/console_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-playground/log"
+	"github.com/go-playground/log/v7"
 )
 
 // NOTES:

--- a/handlers/console/doc.go
+++ b/handlers/console/doc.go
@@ -10,8 +10,8 @@ simple console
     import (
         "errors"
 
-        "github.com/go-playground/log"
-        "github.com/go-playground/log/handlers/console"
+        "github.com/go-playground/log/v7"
+        "github.com/go-playground/log/v7/handlers/console"
     )
 
     func main() {

--- a/handlers/email/doc.go
+++ b/handlers/email/doc.go
@@ -8,8 +8,8 @@ simple email
     package main
 
     import (
-        "github.com/go-playground/log"
-        "github.com/go-playground/log/handlers/email"
+        "github.com/go-playground/log/v7"
+        "github.com/go-playground/log/v7/handlers/email"
     )
 
     func main() {

--- a/handlers/email/email.go
+++ b/handlers/email/email.go
@@ -7,7 +7,7 @@ import (
 
 	gomail "gopkg.in/gomail.v2"
 
-	"github.com/go-playground/log"
+	"github.com/go-playground/log/v7"
 )
 
 // FormatFunc is the function that the workers use to create

--- a/handlers/email/email_test.go
+++ b/handlers/email/email_test.go
@@ -11,7 +11,7 @@ import (
 
 	gomail "gopkg.in/gomail.v2"
 
-	"github.com/go-playground/log"
+	"github.com/go-playground/log/v7"
 )
 
 // NOTES:

--- a/handlers/http/doc.go
+++ b/handlers/http/doc.go
@@ -10,8 +10,8 @@ NOTE: you can use the HTTP handler as a base for creating other handlers
     import (
         stdhttp "net/http"
 
-        "github.com/go-playground/log"
-        "github.com/go-playground/log/handlers/http"
+        "github.com/go-playground/log/v7"
+        "github.com/go-playground/log/v7/handlers/http"
     )
 
     func main() {

--- a/handlers/http/hipchat/doc.go
+++ b/handlers/http/hipchat/doc.go
@@ -8,8 +8,8 @@ NOTE: "/notification" is added to the host url automatically.
 	package main
 
 	import (
-		"github.com/go-playground/log"
-		"github.com/go-playground/log/handlers/http/hipchat"
+		"github.com/go-playground/log/v7"
+		"github.com/go-playground/log/v7/handlers/http/hipchat"
 	)
 
 	func main() {

--- a/handlers/http/hipchat/hipchat.go
+++ b/handlers/http/hipchat/hipchat.go
@@ -9,8 +9,8 @@ import (
 	stdhttp "net/http"
 	"strings"
 
-	"github.com/go-playground/log"
-	"github.com/go-playground/log/handlers/http"
+	"github.com/go-playground/log/v7"
+	"github.com/go-playground/log/v7/handlers/http"
 )
 
 // APIVersion specifies the HipChat API version to use

--- a/handlers/http/hipchat/hipchat_test.go
+++ b/handlers/http/hipchat/hipchat_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/go-playground/log"
+	"github.com/go-playground/log/v7"
 )
 
 // NOTES:

--- a/handlers/http/http.go
+++ b/handlers/http/http.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 	"sync"
 
-	"github.com/go-playground/log"
+	"github.com/go-playground/log/v7"
 )
 
 // FormatFunc is the function that the workers use to create

--- a/handlers/http/http_test.go
+++ b/handlers/http/http_test.go
@@ -6,7 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/go-playground/log"
+	"github.com/go-playground/log/v7"
 )
 
 // NOTES:

--- a/handlers/json/json.go
+++ b/handlers/json/json.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"sync"
 
-	"github.com/go-playground/log"
+	"github.com/go-playground/log/v7"
 )
 
 // Handler implementation.

--- a/handlers/json/json_test.go
+++ b/handlers/json/json_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/go-playground/log"
+	"github.com/go-playground/log/v7"
 )
 
 func TestJSONLogger(t *testing.T) {

--- a/handlers/syslog/doc.go
+++ b/handlers/syslog/doc.go
@@ -12,8 +12,8 @@ NOTE: syslog uses github.com/RackSec/srslog as the stdlib syslog
     import (
         stdsyslog "log/syslog"
 
-        "github.com/go-playground/log"
-        "github.com/go-playground/log/handlers/syslog"
+        "github.com/go-playground/log/v7"
+        "github.com/go-playground/log/v7/handlers/syslog"
     )
 
     func main() {

--- a/handlers/syslog/syslog.go
+++ b/handlers/syslog/syslog.go
@@ -9,7 +9,7 @@ import (
 	syslog "github.com/RackSec/srslog"
 
 	"github.com/go-playground/ansi"
-	"github.com/go-playground/log"
+	"github.com/go-playground/log/v7"
 )
 
 // FormatFunc is the function that the workers use to create

--- a/handlers/syslog/syslog_test.go
+++ b/handlers/syslog/syslog_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-playground/log"
+	"github.com/go-playground/log/v7"
 )
 
 // NOTES:

--- a/log_test.go
+++ b/log_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-playground/errors"
+	"github.com/go-playground/errors/v5"
 )
 
 // NOTES:


### PR DESCRIPTION
This fixes #35. Updated the module definition and sub-modules with the proper import path allowing access to v7. This will likely fail to build until go-playground/pkg#2 and go-playground/errors#10 are pulled in and the `go.mod` files updated to match.